### PR TITLE
sbt-release + sbt-sonatype support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,4 @@
+import ReleaseTransformations._
 
 // ---------
 // Setting / Task Definitions
@@ -45,7 +46,6 @@ lazy val circeVersion = "0.4.1"
 lazy val commonSettings = Seq(
   description := "The missing MatPlotLib for Scala and Spark",
   organization := "com.github.aishfenton",
-  version := "0.2.4",
   scalaVersion := "2.11.8",
   vegaLiteVersion := "1.1.2",
   scalacOptions += "-target:jvm-1.7",
@@ -64,6 +64,7 @@ lazy val commonSettings = Seq(
   },
   publishArtifact in Test := false,
   pomIncludeRepository := { _ => false },
+  sonatypeProfileName := "com.github.aishfenton",
   pomExtra := (
     <scm>
       <url>git@github.com:aishfenton/Vegas.git</url>
@@ -82,9 +83,26 @@ lazy val commonSettings = Seq(
           <id>dbtsai</id>
           <name>DB Tsai</name>
         </developer>
+        <developer>
+          <id>rogermenezes</id>
+          <name>Roger Menezes</name>
+        </developer>
       </developers>
-    )
-
+  ),
+  releaseProcess := Seq[ReleaseStep](
+    checkSnapshotDependencies,
+    inquireVersions,
+    runClean,
+    runTest,
+    setReleaseVersion,
+    commitReleaseVersion,
+    tagRelease,
+    ReleaseStep(action = Command.process("publishSigned", _)),
+    setNextVersion,
+    commitNextVersion,
+    ReleaseStep(action = Command.process("sonatypeReleaseAll", _)),
+    pushChanges
+  )
 )
 
 lazy val noPublishSettings = Seq(

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,3 +5,7 @@ addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.3")
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.1.0")
 
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
+
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "1.1")
+
+addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.3")

--- a/version.sbt
+++ b/version.sbt
@@ -1,0 +1,1 @@
+version in ThisBuild := "0.3.0-SNAPSHOT"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,2 @@
 version in ThisBuild := "0.3.0-SNAPSHOT"
+


### PR DESCRIPTION
Adding SBT plugins that make releases easier. 

Running ```sbt release``` does:
* Runs tests
* Tags the release (which means it goes into the releases section on github)
* Automates the tedious Maven central / Sonatype release process 
* Increments ```version.sbt``` 

New process is also documented in CONTRIB.md.

Also added Roger as author in POM.xml file :)
